### PR TITLE
[API] Fix non-monorepo adds from UI failing for no matchable getPath and nulls in createDTO

### DIFF
--- a/api/modules/entities/dataService.js
+++ b/api/modules/entities/dataService.js
@@ -163,7 +163,7 @@ const _module = {
     const { getDTOValue: getValue, createDTO: create } = _module;
     for (let prop in entity) {
 
-      if(entity[prop] === undefined) {
+      if (typeof entity[prop] === undefined || entity[prop] === null) {
         entity[prop] = '';
       }
 

--- a/api/modules/entities/resourceService.js
+++ b/api/modules/entities/resourceService.js
@@ -48,9 +48,7 @@ const _module = {
             resource = await resourceMetadataService.getMetadata(resource);
 
             if (isRepo) {
-              const metaValues = await livewireMetadataService.getValues(
-                resource
-              );
+              const metaValues = await livewireMetadataService.getValues(resource);
 
               if (metaValues) {
                 resource.title = metaValues.title;
@@ -138,7 +136,7 @@ const _module = {
     if(/\.json$/.test(url)) {
       // Monorepo URL example:
       //   https://github.com/craigshoemaker/livewire-monorepo/blob/main/src/app1/livewire.config.json
-      const matches = url.match(/(https?:\/\/github.com\/.*?\/.*?)\//);
+      const matches = url.match(/(https?:\/\/github\.com\/.*?\/.*?)\//);
       const [match, urlTrimmed] = matches;
       url = urlTrimmed;
     }
@@ -147,9 +145,13 @@ const _module = {
   },
 
   getPath: (url) => {
-    const matches = url.match(/https?:\/\/github.com\/.*?\/.*?\/blob\/.*?\/(.*)\/livewire\.config\.json/);
-    const [match, path] = matches;
-    return path;
+    if (/\.json$/.test(url)) {
+      const matches = url.match(/https?:\/\/github\.com\/.*?\/.*?\/blob\/.*?\/(.*)\/livewire\.config\.json/);
+      const [match, path] = matches;
+      return path;
+    } else {
+      return null;
+    }
   },
 
   getRowKey: (url) => {
@@ -161,7 +163,7 @@ const _module = {
 
       key = url.replace(patterns.GITHUB, "");
       
-      if(/\.json$/.test(url)) {       
+      if (/\.json$/.test(url)) {
         let matches = key.match(/(.*?)\/(.*?)\/blob\/.*?\/(.*)\/livewire\.config\.json/);
         [match, username, reponame, path] = matches;
         key = `${username}:${reponame}:${path}`;

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "functions",
   "version": "1.0.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "requires": true,
   "packages": {
     "": {
@@ -8612,8 +8612,7 @@
     "jest-pnp-resolver": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
-      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "requires": {}
+      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w=="
     },
     "jest-regex-util": {
       "version": "26.0.0",
@@ -10287,11 +10286,6 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -10310,6 +10304,11 @@
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.0"
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "strip-ansi": {
       "version": "6.0.0",


### PR DESCRIPTION
Fixes #48

The issue appears not to have been a blank value for `technologies`, but two-fold:
- The `getStarterObject()` call to `getPath()` (likely added for mono-repo support) was throwing as the example repo (`https://github.com/georgewallace/Get-FileInfoOnContent`) didn't match the `https://github.com/{owner}/{repo}/blob/{branch}/livewire.config.json` format since it isn't a mono-repo.
  - Change made: Added a small test to see if the URL provided ends in `.json` (matching existing tests).  If `.json` is present, treat as mono-repo and get the **Path**, otherwise return a null **Path**.
- The `createDTO()` function for sending the object to storage wasn't property checking undefined and wasn't checking null at all.
  - Change made: Updated `createDTO()` to check for undefined and null.  Needed as the above change was now explicitly setting **Path** to null.

