### PR TITLE
Adjusted for required color contrast ratio

### DIFF
--- a/ui/src/assets/app.css
+++ b/ui/src/assets/app.css
@@ -38,7 +38,7 @@ footer {
 }
 
 button.action {
-  background-color: #2ea44f;
+  background-color: #1d6332;
   @apply text-white rounded-md text-sm p-2;
   height: 37px;
 }

--- a/ui/src/components/AddResource.vue
+++ b/ui/src/components/AddResource.vue
@@ -8,14 +8,14 @@
           class="w-full"
           @focus="stopAutoCancel()"
         />
-        <span class="text-gray-500 text-xs">
+        <span class="text-gray-700 text-xs">
           Enter a GitHub repository, Livewire config file location, or VS Code marketplace URL.
         </span>
       </span>
       <span
         v-if="message.length > 0"
         :class="message.length > 0 ? 'fadeout-5sec-delay' : ''"
-        class="inline-block mt-1 text-gray-500"
+        class="inline-block mt-1 text-gray-700"
         >{{ message }}</span
       >
     </div>

--- a/ui/src/components/MetadataGenerator.vue
+++ b/ui/src/components/MetadataGenerator.vue
@@ -1,7 +1,7 @@
 <template>
   <section id="generator">
     <div v-if="!showForm" class="text-center p-5">
-      <button @click="handleShowForm()" class="text-gray-500">
+      <button @click="handleShowForm()" class="text-gray-700">
         Create config file
       </button>
     </div>
@@ -9,7 +9,7 @@
       <div class="generator">
         <div class="text-right">
           <font-awesome-icon
-            class="cursor-pointer text-gray-500"
+            class="cursor-pointer text-gray-700"
             icon="window-close"
             @click="cancel()"
           />

--- a/ui/src/components/ResourceCard.vue
+++ b/ui/src/components/ResourceCard.vue
@@ -37,7 +37,7 @@
 
         <div
           v-if="isExtensionWithoutGitHubUrl(resource)"
-          class="italic text-gray-500 mt-10 text-sm"
+          class="italic text-gray-700 mt-10 text-sm"
         >
           No GitHub information available.
         </div>

--- a/ui/src/components/ResourceCardList.vue
+++ b/ui/src/components/ResourceCardList.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="sm:px-6 py-4 flex flex-wrap">
     <div
-      class="italic text-xl text-gray-600"
+      class="italic text-xl text-gray-700"
       v-if="!resources || resources.length < 1"
     >
       Loading...


### PR DESCRIPTION
Part of the internal onboarding required running an [accessibility checker](https://accessibilityinsights.io/docs/en/web/reference/help/). It found a few color contrast concerns.

These changes will bring those contrast ratios into compliance, but they do change the visual look of things a bit. Going forward, we might need to focus on using some other method (text styles?) to reflect the same intention where lighter gray text is currently used.

Examples of adjusted output:

* Add button
  * Before
    ![Screenshot of Add button with brighter green background and white text.](https://user-images.githubusercontent.com/713665/142916100-0625e31c-8ea2-47ac-b4c9-8a10ea463057.png)
  * After
    ![Screenshot of Add button with darker green background and white text.](https://user-images.githubusercontent.com/713665/142916768-0c6c5e8f-84d2-4016-9c22-1f172f212bd6.png)
* Config text
  * Before
    ![Screenshot of config creation text with white background and light gray text.](https://user-images.githubusercontent.com/713665/142917252-c68b68b4-f915-4491-81b9-2bde951bd567.png)
  * After
    ![Screenshot of config creation text with white background and darker gray text.](https://user-images.githubusercontent.com/713665/142917296-2bdb3ecc-d602-48dc-b015-c1ac6307cb3c.png)
